### PR TITLE
#78 graphe deces fr tr age

### DIFF
--- a/040_deces_francais.R
+++ b/040_deces_francais.R
@@ -281,7 +281,7 @@ if (exists(varName)) {
 	
 	if (shallDeleteVars) rm(fr_insee_communes)
 	
-	# 
+	# Ajouter les Départements et Régions 
 	dbp <- b__fr_gouv_deces_quotidiens %>%
 			left_join(
 					communes_deduplique %>%
@@ -425,8 +425,9 @@ deces_dep_jour <- deces_dep_jour %>%
 # Ajouter le nom des départements
 
 # Lire le fichier des departements-regions
-nom_departement <- read.csv("data/csv/departements-region.csv", sep=",", header = TRUE, encoding="UTF-8")
+nom_departement <- read.csv("data/csv/departements-region.csv", sep=",", header = TRUE)
 
+# Ajouter les colonnes dep_name et region_name
 deces_dep_jour <- deces_dep_jour %>%
 		left_join(nom_departement,
 				by=c("deces_num_dept"="num_dep"))
@@ -442,6 +443,7 @@ deces_dep_jour <- deces_dep_jour %>%
 						"pas de confinement"))
 
 # Filtrer les deces par region
+
 BourgogneFrancheComte <- deces_dep_jour %>%
 		filter(region_name == "Bourgogne-Franche-Comté")
 


### PR DESCRIPTION
Pierre, 

Voici une autre correction à prendre en compte.

Dans les read.csv(), il ne faut pas indiquer l'encoding (par contre, on peut mettre le fileencoding éventuellement, mais ça ne semble pas nécessaire si les fichiers sont déjà en UTF-8).

J'ai galéré toute l'après-midi pour comprendre ça, car les filter() ne retrouvaient plus les régions contenant des accents !

A+